### PR TITLE
Bump versions and improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ easily mock or stub out the database using a tool like [Shrubbery][].
 
 [shrubbery]: https://github.com/bguthrie/shrubbery
 
+## Example
+
+Consider a redis database where users are stored as hashmap with keys
+like `user:{username}`.
+
+The connection spec needed by Carmine can be extracted from this module
+`Boundary` by using the `:conn-opts` key.
+
+```clojure
+(ns my-project.boundary.user-db
+  (:require [duct.database.redis.carmine]
+            [taoensso.carmine :as car :refer (wcar)]))
+            
+(defprotocol UserDatabase
+  (get-user [db username]))
+  
+(extend-protocol UserDatabase
+  duct.database.redis.carmine.Boundary
+  (get-user [db username]
+    (car/wcar (:conn-opts db) 
+      (car/hgetall (str "user:" username))))) 
+```
+
 ## License
 
 Copyright © 2017 James Reeves

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/duct-framework/database.redis.carmine"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
-                 [com.taoensso/carmine "2.16.0"]
-                 [integrant "0.4.0"]])
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [com.taoensso/carmine "2.18.1"]
+                 [integrant "0.7.0-alpha2"]])


### PR DESCRIPTION
Bump versions of Clojure, carmine and integrant.
Improves the README by explaining about `:conn-opts` and show a small example of `Boundary` implementation.